### PR TITLE
Fix import paths and ensure Python 3.8.1 compatibility for validate tests

### DIFF
--- a/tests/test_validate/test_validate_boolean.py
+++ b/tests/test_validate/test_validate_boolean.py
@@ -1,0 +1,158 @@
+# File: tests/test_validate/test_validate_boolean.py
+
+from typing import Any
+
+import pytest
+
+from lionfuncs.validate.validate_boolean import (
+    FALSE_VALUES,
+    TRUE_VALUES,
+    validate_boolean,
+)
+
+
+class TestValidateBoolean:
+    """Tests for validate_boolean function."""
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_boolean_inputs(self, value: bool):
+        """Test that boolean inputs are returned unchanged."""
+        assert validate_boolean(value) is value
+
+    @pytest.mark.parametrize("value", TRUE_VALUES)
+    def test_true_string_values(self, value: str):
+        """Test string values that should convert to True."""
+        assert validate_boolean(value) is True
+        assert validate_boolean(value.upper()) is True
+        assert validate_boolean(f" {value} ") is True
+
+    @pytest.mark.parametrize("value", FALSE_VALUES)
+    def test_false_string_values(self, value: str):
+        """Test string values that should convert to False."""
+        assert validate_boolean(value) is False
+        assert validate_boolean(value.upper()) is False
+        assert validate_boolean(f" {value} ") is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            0.0,
+            -0,
+            0j,  # Should be False
+            1,
+            -1,
+            1.5,
+            42,
+            float("inf"),
+            complex(1, 1),  # Should be True
+        ],
+    )
+    def test_numeric_values(self, value: Any):
+        """Test numeric values conversion."""
+        expected = bool(value)
+        assert validate_boolean(value) is expected
+
+    def test_complex_numbers(self):
+        """Test complex number handling specifically."""
+        # Zero complex numbers should be False
+        assert validate_boolean(0j) is False
+        assert validate_boolean(complex(0)) is False
+        assert validate_boolean(complex(0, 0)) is False
+
+        # Non-zero complex numbers should be True
+        assert validate_boolean(1j) is True
+        assert validate_boolean(complex(1, 1)) is True
+        assert validate_boolean(complex(0, 1)) is True
+        assert validate_boolean(complex(1, 0)) is True
+
+    def test_error_cases(self):
+        """Test cases that should raise errors."""
+        # Test None
+        with pytest.raises(TypeError, match="Cannot convert None to boolean"):
+            validate_boolean(None)
+
+        # Test empty string
+        with pytest.raises(
+            ValueError, match="Cannot convert empty string to boolean"
+        ):
+            validate_boolean("")
+        with pytest.raises(
+            ValueError, match="Cannot convert empty string to boolean"
+        ):
+            validate_boolean("   ")
+
+        # Test invalid strings
+        with pytest.raises(ValueError):
+            validate_boolean("invalid")
+        with pytest.raises(ValueError):
+            validate_boolean("truthy")
+        with pytest.raises(ValueError):
+            validate_boolean("falsey")
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            # Test various number-like strings
+            ("1.0", True),
+            ("-1", True),
+            ("0.0", False),
+            ("0j", False),  # Complex number strings
+            ("1j", True),
+            ("1+1j", True),
+            # Test various casings
+            ("TRUE", True),
+            ("False", False),
+            ("YeS", True),
+            ("nO", False),
+            # Test with whitespace
+            ("  true  ", True),
+            ("  false  ", False),
+            # Test alternative representations
+            ("enable", True),
+            ("disable", False),
+            ("activated", True),
+            ("deactivated", False),
+        ],
+    )
+    def test_variations(self, value: Any, expected: bool):
+        """Test various input variations."""
+        assert validate_boolean(value) is expected
+
+    def test_object_conversion(self):
+        """Test conversion of objects with __str__ method."""
+
+        class TrueObject:
+            def __str__(self):
+                return "true"
+
+        class FalseObject:
+            def __str__(self):
+                return "false"
+
+        assert validate_boolean(TrueObject()) is True
+        assert validate_boolean(FalseObject()) is False
+
+    def test_invalid_objects(self):
+        """Test objects that cannot be converted."""
+
+        class BadObject:
+            def __str__(self):
+                raise Exception("Cannot convert to string")
+
+        with pytest.raises(TypeError):
+            validate_boolean(BadObject())
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            object(),  # Generic object
+            lambda x: x,  # Function
+            ...,  # Ellipsis
+            range(5),  # Range object
+        ],
+    )
+    def test_unsupported_types(self, value: Any):
+        """Test handling of unsupported types."""
+        with pytest.raises((ValueError, TypeError)):
+            validate_boolean(value)

--- a/tests/test_validate/test_validate_keys.py
+++ b/tests/test_validate/test_validate_keys.py
@@ -1,0 +1,159 @@
+# File: tests/test_validate/test_validate_key.py
+
+from typing import Any
+
+import pytest
+
+from lionfuncs.validate.validate_keys import validate_keys
+
+
+class TestValidateKeys:
+    """Comprehensive tests for validate_keys function."""
+
+    def test_basic_functionality(self):
+        """Test basic functionality with default parameters."""
+        test_dict = {
+            "user_name": "John",
+            "email_addr": "john@example.com",
+        }
+        expected = ["username", "email_address"]
+
+        result = validate_keys(test_dict, expected)
+        # With default settings, original keys should be preserved
+        assert "username" in result
+        assert "email_address" in result
+
+    def test_exact_matches(self):
+        """Test when keys exactly match expected keys."""
+        exact_dict = {
+            "username": "John",
+            "email_address": "john@example.com",
+        }
+        expected = ["username", "email_address"]
+        result = validate_keys(exact_dict, expected)
+        assert result == exact_dict
+
+    def test_empty_inputs(self):
+        """Test empty input scenarios."""
+        # Empty dictionary
+        assert validate_keys({}, []) == {}
+
+        # Empty expected keys
+        result = validate_keys({"a": 1}, [])
+        assert result == {"a": 1}
+
+    def test_fuzzy_matching(self):
+        """Test fuzzy matching with different thresholds."""
+        test_dict = {"user_name": "John", "emailAddress": "john@example.com"}
+        expected = ["username", "email_address"]
+
+        # Test with fuzzy matching enabled and remove unmatched
+        result = validate_keys(
+            test_dict,
+            expected,
+            fuzzy_match=True,
+            similarity_threshold=0.7,
+            handle_unmatched="remove",
+        )
+        assert "username" in result
+        assert "email_address" in result
+        assert "user_name" not in result
+        assert "emailAddress" not in result
+
+        # Test with fuzzy matching disabled
+        result_no_fuzzy = validate_keys(test_dict, expected, fuzzy_match=False)
+        assert "user_name" in result_no_fuzzy
+        assert "emailAddress" in result_no_fuzzy
+
+    def test_handle_unmatched_modes(self):
+        """Test different handle_unmatched modes."""
+        test_dict = {"user_name": "John", "extra": "value"}
+        expected = ["username"]
+
+        # Test raise mode
+        with pytest.raises(ValueError):
+            validate_keys(test_dict, expected, handle_unmatched="raise")
+
+        # Test remove mode
+        result_remove = validate_keys(
+            test_dict, expected, handle_unmatched="remove"
+        )
+        assert "extra" not in result_remove
+
+        # Test fill mode
+        result_fill = validate_keys(
+            test_dict, expected, handle_unmatched="fill", fill_value="default"
+        )
+        assert "extra" in result_fill
+        assert "username" in result_fill
+
+        # Test force mode
+        result_force = validate_keys(
+            test_dict, expected, handle_unmatched="force", fill_value="default"
+        )
+        assert "extra" not in result_force
+        assert "username" in result_force
+
+    def test_strict_mode(self):
+        """Test strict mode behavior."""
+        test_dict = {"partial": "value"}
+        expected = ["partial", "missing"]
+
+        with pytest.raises(ValueError):
+            validate_keys(test_dict, expected, strict=True)
+
+        result = validate_keys(test_dict, expected, strict=False)
+        assert "partial" in result
+
+    def test_edge_cases_and_invalid_inputs(self):
+        """Test edge cases and invalid inputs."""
+        valid_dict = {"key": "value"}
+        valid_keys = ["key"]
+
+        # Invalid similarity threshold
+        with pytest.raises(ValueError):
+            validate_keys(valid_dict, valid_keys, similarity_threshold=1.5)
+
+        # None input dictionary
+        with pytest.raises(TypeError):
+            validate_keys(None, valid_keys)
+
+        # None keys
+        with pytest.raises(TypeError):
+            validate_keys(valid_dict, None)
+
+        # Invalid similarity algorithm
+        with pytest.raises(ValueError):
+            validate_keys(valid_dict, valid_keys, similarity_algo="invalid")
+
+    def test_fill_value_and_mapping(self):
+        """Test fill value and mapping functionality."""
+        test_dict = {"existing": "value"}
+        expected = ["existing", "missing1", "missing2"]
+        fill_mapping = {"missing1": "custom1", "missing2": "custom2"}
+
+        result = validate_keys(
+            test_dict,
+            expected,
+            handle_unmatched="fill",
+            fill_mapping=fill_mapping,
+        )
+        assert result["missing1"] == "custom1"
+        assert result["missing2"] == "custom2"
+
+    def test_custom_similarity_function(self):
+        """Test using a custom similarity function."""
+
+        def custom_similarity(s1: str, s2: str) -> float:
+            return 1.0 if s1.lower() == s2.lower() else 0.0
+
+        test_dict = {"User_Name": "John"}
+        expected = ["user_name"]
+
+        result = validate_keys(
+            test_dict,
+            expected,
+            similarity_algo=custom_similarity,
+            fuzzy_match=True,
+        )
+        assert len(result) > 0

--- a/tests/test_validate/test_validate_mapping.py
+++ b/tests/test_validate/test_validate_mapping.py
@@ -1,0 +1,158 @@
+# File: tests/test_validate/test_validate_mapping.py
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from lionfuncs.validate.validate_mapping import validate_mapping
+
+
+class TestValidateMapping:
+    """Tests for validate_mapping function."""
+
+    def test_basic_dictionary_input(self):
+        """Test basic dictionary input."""
+        test_dict = {"name": "John", "age": 30}
+        result = validate_mapping(test_dict, ["name", "age"])
+        assert result == test_dict
+
+    def test_string_inputs(self):
+        """Test string input parsing."""
+        # JSON string
+        json_input = '{"name": "John", "age": 30}'
+        result = validate_mapping(json_input, ["name", "age"])
+        assert result == {"name": "John", "age": 30}
+
+        # JSON with single quotes
+        single_quote = "{'name': 'John', 'age': 30}"
+        result = validate_mapping(single_quote, ["name", "age"])
+        assert result == {"name": "John", "age": 30}
+
+        # JSON in code block
+        code_block = """```json
+        {"name": "John", "age": 30}
+        ```"""
+        result = validate_mapping(code_block, ["name", "age"])
+        assert result == {"name": "John", "age": 30}
+
+    def test_type_conversion(self):
+        """Test model conversion."""
+
+        class UserModel(BaseModel):
+            name: str
+            age: int
+
+        user = UserModel(name="John", age=30)
+        result = validate_mapping(user, ["name", "age"])
+        assert result == {"name": "John", "age": 30}
+
+    @pytest.mark.parametrize(
+        "handle_unmatched,expected_keys",
+        [
+            ("ignore", {"name", "extra"}),
+            ("remove", {"name"}),
+            ("fill", {"name", "age", "extra"}),
+            ("force", {"name", "age"}),
+        ],
+    )
+    def test_handle_unmatched_modes(self, handle_unmatched, expected_keys):
+        """Test different handle_unmatched modes."""
+        input_dict = {"name": "John", "extra": "value"}
+        result = validate_mapping(
+            input_dict,
+            ["name", "age"],
+            handle_unmatched=handle_unmatched,
+            fill_value=None,
+        )
+        assert set(result.keys()) == expected_keys
+
+    def test_handle_unmatched_raise(self):
+        """Test raise mode for unmatched keys."""
+        with pytest.raises(ValueError):
+            validate_mapping(
+                {"name": "John", "extra": "value"},
+                ["name"],
+                handle_unmatched="raise",
+            )
+
+    def test_fill_values(self):
+        """Test fill value functionality."""
+        input_dict = {"name": "John"}
+        fill_mapping = {"age": 30, "email": "test@example.com"}
+
+        result = validate_mapping(
+            input_dict,
+            ["name", "age", "email"],
+            handle_unmatched="fill",
+            fill_mapping=fill_mapping,
+        )
+        assert result == {
+            "name": "John",
+            "age": 30,
+            "email": "test@example.com",
+        }
+
+    @pytest.mark.parametrize(
+        "threshold,expected_match",
+        [
+            (0.95, None),  # High threshold - won't match
+            (0.6, "username"),  # Low threshold - will match
+        ],
+    )
+    def test_similarity_thresholds(self, threshold, expected_match):
+        """Test different similarity thresholds."""
+        result = validate_mapping(
+            {"user_name": "John"},
+            ["username"],
+            similarity_threshold=threshold,
+            handle_unmatched="remove",
+        )
+        if expected_match:
+            assert expected_match in result
+        else:
+            assert "username" in result
+
+    def test_error_cases(self):
+        """Test error handling."""
+
+        # None input
+        with pytest.raises(TypeError):
+            validate_mapping(None, ["key"])
+
+        # Empty input with strict mode
+        with pytest.raises(ValueError):
+            validate_mapping({}, ["required_key"], strict=True)
+
+    def test_strict_mode(self):
+        """Test strict mode validation."""
+        with pytest.raises(ValueError):
+            validate_mapping(
+                {"name": "John"}, ["name", "required_field"], strict=True
+            )
+
+    def test_custom_similarity(self):
+        """Test custom similarity function."""
+
+        def case_insensitive_match(s1: str, s2: str) -> float:
+            return 1.0 if s1.lower() == s2.lower() else 0.0
+
+        result = validate_mapping(
+            {"USER_NAME": "John"},
+            ["username"],
+            similarity_algo=case_insensitive_match,
+            handle_unmatched="remove",
+        )
+        assert "username" not in result
+
+    def test_suppress_conversion_errors(self):
+        """Test error suppression."""
+        # Should return empty dict with suppress_conversion_errors
+        result = validate_mapping(
+            object(),
+            ["key"],
+            suppress_conversion_errors=True,
+            handle_unmatched="fill",
+            fill_value=None,
+        )
+        assert result == {"key": None}


### PR DESCRIPTION
Update import paths and ensure Python 3.8.1 compatibility for test files under `tests/test_validate/`.

* **tests/test_validate/test_validate_boolean.py**
  - Add import statement for `validate_boolean` from `lionfuncs.validate.validate_boolean`.
  - Add comprehensive test cases to verify the functionality of `validate_boolean`.
  - Ensure compatibility with Python 3.8.1.

* **tests/test_validate/test_validate_keys.py**
  - Add import statement for `validate_keys` from `lionfuncs.validate.validate_keys`.
  - Add comprehensive test cases to verify the functionality of `validate_keys`.
  - Ensure compatibility with Python 3.8.1.

* **tests/test_validate/test_validate_mapping.py**
  - Add import statement for `validate_mapping` from `lionfuncs.validate.validate_mapping`.
  - Add comprehensive test cases to verify the functionality of `validate_mapping`.
  - Ensure compatibility with Python 3.8.1.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lion-agi/lionfuncs?shareId=78cce811-34b5-480d-8ffe-c0bdf8cd66d0).